### PR TITLE
Fix for "Could not find number of forks."

### DIFF
--- a/github.lua
+++ b/github.lua
@@ -423,7 +423,7 @@ wget.callbacks.get_urls = function(file, url, is_css, iri)
         abortgrab = true
       end
       stars = tonumber(match)
-      match = string.match(html, '<a[^>]+href="[^"]+/network/members"[^>]+aria%-label="([0-9]+) users? forked this repository">')
+      match = string.match(html, '<a[^>]+href="[^"]+/network/members"[^>]+aria%-label="([0-9]+) users? forked this repository"[^>]')
       if not match then
         io.stdout:write("Could not find number of forks.\n")
         io.stdout:flush()


### PR DESCRIPTION
Github added more whitespace to the fork counter, breaking the fork number detection pattern. This has not been tested but should work fine. (some more details on IRC)